### PR TITLE
Made Weekly adherence dates clickable

### DIFF
--- a/passio-ui-module/src/main/java/ai/passio/nutrition/uimodule/ui/dashboard/DashboardFragment.kt
+++ b/passio-ui-module/src/main/java/ai/passio/nutrition/uimodule/ui/dashboard/DashboardFragment.kt
@@ -82,10 +82,15 @@ class DashboardFragment : BaseFragment<DashboardViewModel>() {
     private fun setupCalendarView() {
         with(binding) {
 //            calendarView.currentDate = CalendarDay.today()
-            val aa = DateTime.now()//.plusDays(2)
-            calendarView.selectedDate = CalendarDay.from(aa.year, aa.monthOfYear, aa.dayOfMonth)
+            val todayDate = DateTime.now()//.plusDays(2)
+            calendarView.selectedDate = CalendarDay.from(todayDate.year, todayDate.monthOfYear, todayDate.dayOfMonth)
 
             viewModel.fetchAdherence()
+
+            calendarView.setOnDateChangedListener { _, date, _ ->
+                sharedViewModel.setDiaryDate(DateTime(date.year, date.month, date.day, 0, 0).toDate())
+                viewModel.navigateToDiary()
+            }
         }
     }
 
@@ -201,6 +206,7 @@ class DashboardFragment : BaseFragment<DashboardViewModel>() {
             calendarView.invalidateDecorators()
             viewModel.fetchLogsForCurrentDay()
 
+
         }
     }
 
@@ -218,6 +224,7 @@ class DashboardFragment : BaseFragment<DashboardViewModel>() {
                 SelectedDayDecorator(requireContext(), calendarView),
                 DisableDateSelectionDecorator()
             )
+
         }
 
     }

--- a/passio-ui-module/src/main/java/ai/passio/nutrition/uimodule/ui/dashboard/DashboardViewModel.kt
+++ b/passio-ui-module/src/main/java/ai/passio/nutrition/uimodule/ui/dashboard/DashboardViewModel.kt
@@ -154,5 +154,10 @@ class DashboardViewModel : BaseViewModel() {
             navigate(DashboardFragmentDirections.dashboardToWaterTracking(currentDate = currentDate.time))
         }
     }
+    fun navigateToDiary() {
+        viewModelScope.launch(Dispatchers.Main) {
+            navigate(DashboardFragmentDirections.dashboardToDiary())
+        }
+    }
 
 }

--- a/passio-ui-module/src/main/java/ai/passio/nutrition/uimodule/ui/dashboard/MyDayViewDecorator.kt
+++ b/passio-ui-module/src/main/java/ai/passio/nutrition/uimodule/ui/dashboard/MyDayViewDecorator.kt
@@ -165,10 +165,10 @@ class FutureDaysDecorator(private val context: Context) : DayViewDecorator {
 
 class DisableDateSelectionDecorator : DayViewDecorator {
     override fun shouldDecorate(day: CalendarDay): Boolean {
-        return true // Apply this decorator to all days
+        return false // Apply this decorator to all days
     }
 
     override fun decorate(view: DayViewFacade) {
-        view.setDaysDisabled(true) // Disable selection for this day
+//        view.setDaysDisabled(true) // Disable selection for this day
     }
 }

--- a/passio-ui-module/src/main/res/navigation/main_nav_graph.xml
+++ b/passio-ui-module/src/main/res/navigation/main_nav_graph.xml
@@ -49,6 +49,11 @@
         <action
             android:id="@+id/dashboard_to_settings"
             app:destination="@id/settings" />
+        <action
+            android:id="@+id/dashboard_to_diary"
+            app:destination="@id/diary"
+            app:launchSingleTop="true"
+            app:popUpTo="@id/dashboard" />
 
     </fragment>
 


### PR DESCRIPTION
https://app.zenhub.com/workspaces/nutrition-ai-6553a6e30a14f004a13d6dac/issues/gh/passiolife/android-demo-app/45

When clicking on a date in the Weekly Adherence calendar, the app should open that date in the Diary screen